### PR TITLE
Ignore Sonar builds on Dependabot branches

### DIFF
--- a/.github/workflows/SonarBuild.yml
+++ b/.github/workflows/SonarBuild.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
Due to security reasons, Sonar does not have access to run analysis on bot-initated branches such as the Dependabot ones. This PR disables Sonar analysis for these branches.