### PR TITLE
Validate types (typ) to be a valid JWT

### DIFF
--- a/Fhi.HelseId.Api/HelseIdOptionsExtensions.cs
+++ b/Fhi.HelseId.Api/HelseIdOptionsExtensions.cs
@@ -32,6 +32,7 @@ namespace Fhi.HelseId.Api
                         ValidateIssuerSigningKey = true,
                         ValidateAudience = true,
                         ValidateLifetime = true,
+                        ValidTypes = ["at+jwt", "JWT"]
                     };
                 }
             );

--- a/Fhi.HelseId.Web/ExtensionMethods/HelseIdExtensions.cs
+++ b/Fhi.HelseId.Web/ExtensionMethods/HelseIdExtensions.cs
@@ -42,6 +42,7 @@ namespace Fhi.HelseId.Web.ExtensionMethods
 #endif
             options.ResponseType = "code";
             options.TokenValidationParameters.ValidAudience = configAuth.ClientId;
+            options.TokenValidationParameters.ValidTypes = ["at+jwt", "JWT"];
             options.CallbackPath = "/signin-callback";
             options.SignedOutCallbackPath = "/signout-callback";
             options.Scope.Clear();


### PR DESCRIPTION
NHN sikkerhetsprofil [sier](https://utviklerportal.nhn.no/informasjonstjenester/helseid/protokoller-og-sikkerhetsprofil/sikkerhetsprofil/docs/vedlegg/validering_av_access_token_no_nbmd/):
> API-et **må** bekrefte at verdien for typ-headeren i Access-tokenet er at+jwt eller JWT, og avvise ethvert Access-token som har en annen verdi.

Denne PRen legger inn dette som et absolutt krav. Tidligere har typen vært implisitt og vi har ikke brukt typen til noe.