### PR TITLE
Remove reference to Microsoft.AspNetCore.HeaderPropagation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="6.0.33" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.33" />
     <PackageVersion Include="Microsoft.AspNetCore.Components" Version="6.0.33" />
-    <PackageVersion Include="Microsoft.AspNetCore.HeaderPropagation" Version="6.0.33" />
     <PackageVersion Include="System.ServiceModel.Http" Version="6.2.0" />
     <PackageVersion Include="System.ServiceModel.Primitives" Version="6.2.0" />
   </ItemGroup>
@@ -45,7 +44,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="8.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.8" />
     <PackageVersion Include="System.ServiceModel.Http" Version="8.0.0" />
     <PackageVersion Include="System.ServiceModel.Primitives" Version="8.0.0" />
   </ItemGroup>
@@ -53,7 +51,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0-rc.1.24452.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0-rc.1.24452.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0-rc.1.24452.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.0-rc.1.24452.1" />
     <PackageVersion Include="System.ServiceModel.Http" Version="8.0.0" />
     <PackageVersion Include="System.ServiceModel.Primitives" Version="8.0.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,6 +53,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0-rc.1.24452.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0-rc.1.24452.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0-rc.1.24452.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.0-rc.1.24452.1" />
     <PackageVersion Include="System.ServiceModel.Http" Version="8.0.0" />
     <PackageVersion Include="System.ServiceModel.Primitives" Version="8.0.0" />
   </ItemGroup>

--- a/Fhi.HelseId.Blazor/Fhi.HelseId.Blazor.csproj
+++ b/Fhi.HelseId.Blazor/Fhi.HelseId.Blazor.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components" />
     <PackageReference Include="Refit" />
     <PackageReference Include="Refit.HttpClientFactory" />
-    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>

--- a/Fhi.HelseId.Refit/Fhi.HelseId.Refit.csproj
+++ b/Fhi.HelseId.Refit/Fhi.HelseId.Refit.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Refit" />
     <PackageReference Include="Refit.HttpClientFactory" />
-    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 


### PR DESCRIPTION
Helseid doesn't use the NuGet package Microsoft.AspNetCore.HeaderPropagation directly, and can be removed. We think this package is included to serve consumers.

We have two options to consider:
1. Remove the references for Net6 and Net8.
2. Add a reference for Net9.

This PR selects option 2.

@OsirisTerje Would it be better to exclude this package from Helseid, allowing consumers to include it as needed? This approach could help reduce the size of Helseid and ensure that consumers aren't reliant on Helseid for updates, such as in the case of security issues.