### PR TITLE
Fixed a bug with DPoP Htu claims having query params

### DIFF
--- a/Fhi.HelseId.Tests/AuthorizationHeaderSetterTests.cs
+++ b/Fhi.HelseId.Tests/AuthorizationHeaderSetterTests.cs
@@ -16,7 +16,7 @@ public class AuthorizationHeaderSetterTests
     [SetUp]
     public void SetUp()
     {
-        _request = new HttpRequestMessage(HttpMethod.Get, "https://example.com");
+        _request = new HttpRequestMessage(HttpMethod.Get, "https://example.com?whatever");
     }
 
     [TearDown]
@@ -50,7 +50,9 @@ public class AuthorizationHeaderSetterTests
         var proofToken = "proof-token";
 
         var dPoPTokenCreator = Substitute.For<IDPoPTokenCreator>();
-        dPoPTokenCreator.CreateSignedToken(_request.Method, _request.RequestUri!.ToString(), ath: athValue)
+        var expectedRequestUri = _request.RequestUri!.Scheme + "://" + _request.RequestUri!.Authority +
+                                 _request.RequestUri!.LocalPath;
+        dPoPTokenCreator.CreateSignedToken(_request.Method, expectedRequestUri, ath: athValue)
             .Returns(Task.FromResult(proofToken));
 
         var dPoPHeaderSetter = new DPoPAuthorizationHeaderSetter(dPoPTokenCreator);

--- a/Fhi.HelseId.Web/AuthorizationHeaderSetter.cs
+++ b/Fhi.HelseId.Web/AuthorizationHeaderSetter.cs
@@ -27,7 +27,9 @@ public class DPoPAuthorizationHeaderSetter(IDPoPTokenCreator dPoPTokenCreator) :
         request.Headers.Authorization = new AuthenticationHeaderValue(AuthorizationScheme.DPoP, token);
 
         var athValue = AccessTokenHash.Sha256(token);
-        var proof = await dPoPTokenCreator.CreateSignedToken(request.Method, request.RequestUri!.ToString(), ath: athValue);
+        var requestUri = request.RequestUri!.Scheme + "://" + request.RequestUri!.Authority +
+                         request.RequestUri!.LocalPath;
+        var proof = await dPoPTokenCreator.CreateSignedToken(request.Method, requestUri, ath: athValue);
         request.Headers.Add(DPoPHttpHeaders.ProofHeaderName, proof);
     }
 }


### PR DESCRIPTION
From RFC9449:
> The htu claim matches the HTTP URI value for the HTTP request in which the JWT was received, ignoring any query and fragment parts.

With token forwarding in .Web projects we sent in the entire request URL which also included the query and fragment parts. This PR fixes this problem.