### PR TITLE
Fixes CS7022 - The entry point of the program is global code

### DIFF
--- a/Fhi.HelseId.Integration.Tests/Fhi.HelseId.Integration.Tests.csproj
+++ b/Fhi.HelseId.Integration.Tests/Fhi.HelseId.Integration.Tests.csproj
@@ -7,6 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Ignoring 'AutoGeneratedProgram.Main(string[])' entry point.