### PR TITLE
Use CheckoutV4 action to build NuGet packages

### DIFF
--- a/.github/workflows/Fhi.HelseId.Nuget.yml
+++ b/.github/workflows/Fhi.HelseId.Nuget.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
Today we use CheckoutV2 which gives us deprecation warnings during execution of the build action:
![image](https://github.com/user-attachments/assets/d01250dc-0064-4b75-8fc9-8cf4c5504264)
We can just move to v4 to fix this.