### PR TITLE
Protected paths middleware must accept requests to endpoints with [AllowAnomymous]

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-      <VersionPrefix>6.2.1</VersionPrefix>
+      <VersionPrefix>6.3.0</VersionPrefix>
       <authors>Folkehelseinstituttet (FHI), Nasjonalt Helsenett (NHN)</authors>
       <Copyright>(c) 2020-2024 Folkehelseinstituttet (FHI), Nasjonalt Helsenett (NHN)</Copyright>
       <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>


### PR DESCRIPTION
Previously we set up web applications like this:

```csharp
app.UseAuthentication();
app.UseAuthorization();

app.UseEndpoints(endpoints =>
{
    endpoints.MapControllers();
});

app.UseHelseIdProtectedPaths();
```

But with newer .NET-versions we use `MapControllers` instead of `UseEndpoints`: 

```csharp
app.UseAuthentication();
app.UseAuthorization();

app.MapControllers();

app.UseHelseIdProtectedPaths();
```

The biggest change is that there is no longer a middleware that picks up the incoming http requests before the requested paths middleware. Every request will therefore go through the protected paths middleware. In the event that a user is calling an endpoint with `[AllowAnonymous]`, the middleware will reject the request and result in an unauthorized response. The change in this PR will let calls to endpoints with `[AllowAnonymous]` through.
