### PR TITLE
Fixes warning CS0618 - 'ISystemClock' is obsolete: 'Use TimeProv…

### DIFF
--- a/Fhi.HelseId.Web/Handlers/NoAuthenticationHandler.cs
+++ b/Fhi.HelseId.Web/Handlers/NoAuthenticationHandler.cs
@@ -16,8 +16,10 @@ namespace Fhi.HelseId.Web.Handlers
     {
         private readonly NoAuthenticationUser _noAuthenticationUserConfig;
 
+#pragma warning disable CS0618 // TODO: Use TimeProvider instead. Can be removed when support for Net6.0 is removed.
         public NoAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IOptions<HelseIdWebKonfigurasjon> helseIdWebOptions)
             : base(options, logger, encoder, clock)
+#pragma warning restore CS0618
         {
             _noAuthenticationUserConfig = helseIdWebOptions.Value.NoAuthenticationUser ?? throw new ArgumentException(nameof(HelseIdWebKonfigurasjon.NoAuthenticationUser));
         }

--- a/Fhi.HelseId.Web/Handlers/NoAuthenticationHandler.cs
+++ b/Fhi.HelseId.Web/Handlers/NoAuthenticationHandler.cs
@@ -16,13 +16,20 @@ namespace Fhi.HelseId.Web.Handlers
     {
         private readonly NoAuthenticationUser _noAuthenticationUserConfig;
 
-#pragma warning disable CS0618 // TODO: Use TimeProvider instead. Can be removed when support for Net6.0 is removed.
+
+#if NET6_0
         public NoAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IOptions<HelseIdWebKonfigurasjon> helseIdWebOptions)
             : base(options, logger, encoder, clock)
-#pragma warning restore CS0618
         {
             _noAuthenticationUserConfig = helseIdWebOptions.Value.NoAuthenticationUser ?? throw new ArgumentException(nameof(HelseIdWebKonfigurasjon.NoAuthenticationUser));
         }
+#else
+        public NoAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, IOptions<HelseIdWebKonfigurasjon> helseIdWebOptions)
+            : base(options, logger, encoder)
+        {
+            _noAuthenticationUserConfig = helseIdWebOptions.Value.NoAuthenticationUser ?? throw new ArgumentException(nameof(HelseIdWebKonfigurasjon.NoAuthenticationUser));
+        }
+#endif
 
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {

--- a/Fhi.HelseId.Web/Infrastructure/AutomaticTokenManagement/AutomaticTokenManagementCookieEvents.cs
+++ b/Fhi.HelseId.Web/Infrastructure/AutomaticTokenManagement/AutomaticTokenManagementCookieEvents.cs
@@ -18,9 +18,11 @@ public class AutomaticTokenManagementCookieEvents : CookieAuthenticationEvents
     private readonly TokenEndpointService _service;
     private readonly AutomaticTokenManagementOptions _tokenConfig;
     private readonly ILogger _logger;
-#pragma warning disable CS0618 // TODO: Use TimeProvider instead. Can be removed when support for Net6.0 is removed.
+#if NET6_0
     private readonly ISystemClock _clock;
-#pragma warning restore CS0618
+#else
+    private readonly TimeProvider _clock;
+#endif
     private readonly HelseIdWebKonfigurasjon _helseIdConfig;
     private readonly IRefreshTokenStore _refreshTokenStore;
 
@@ -30,9 +32,11 @@ public class AutomaticTokenManagementCookieEvents : CookieAuthenticationEvents
         TokenEndpointService service,
         IOptions<AutomaticTokenManagementOptions> tokenOptions,
         ILogger<AutomaticTokenManagementCookieEvents> logger,
-#pragma warning disable CS0618 // TODO: Use TimeProvider instead. Can be removed when support for Net6.0 is removed.
+#if NET6_0
         ISystemClock clock,
-#pragma warning restore CS0618
+#else
+        TimeProvider clock,
+#endif
         IOptions<HelseIdWebKonfigurasjon> helseIdOptions,
         IRefreshTokenStore refreshTokenStore)
     {
@@ -93,10 +97,15 @@ public class AutomaticTokenManagementCookieEvents : CookieAuthenticationEvents
         }
 
         var dtRefresh = dtExpires.Subtract(_tokenConfig.RefreshBeforeExpiration); //.Subtract(new TimeSpan(0,7,0)); // For testing it faster
-        _logger.LogTrace("ValidatePrincipal: expires_at: {dtExpires}, refresh_before: {refreshBeforeExpiration}, refresh_at: {dtRefresh}, now: {utcNow}, refresh_token: {refreshToken}, NoOfTokensInStore {noOfRefreshTokens}", dtExpires, _tokenConfig.RefreshBeforeExpiration, dtRefresh, _clock.UtcNow, refreshToken.Value, _refreshTokenStore.RefreshTokens.Count);
+#if NET6_0
+        var utcNow = _clock.UtcNow;
+#else
+        var utcNow = _clock.GetUtcNow();
+#endif
+        _logger.LogTrace("ValidatePrincipal: expires_at: {dtExpires}, refresh_before: {refreshBeforeExpiration}, refresh_at: {dtRefresh}, now: {utcNow}, refresh_token: {refreshToken}, NoOfTokensInStore {noOfRefreshTokens}", dtExpires, _tokenConfig.RefreshBeforeExpiration, dtRefresh, utcNow, refreshToken.Value, _refreshTokenStore.RefreshTokens.Count);
         if (_helseIdConfig.UseApis)
         {
-            if (dtRefresh < _clock.UtcNow)
+            if (dtRefresh < utcNow)
             {
                 var shouldRefresh = PendingRefreshTokenRequests.TryAdd(rfValue, true);
                 _logger.LogTrace("{class}:{method} - Should refresh: {shouldRefresh}, No Of tokens in PendingRefreshTokenRequests {count} ", nameof(AutomaticTokenManagementCookieEvents), nameof(ValidatePrincipal), shouldRefresh, PendingRefreshTokenRequests.Count);

--- a/Fhi.HelseId.Web/Infrastructure/AutomaticTokenManagement/AutomaticTokenManagementCookieEvents.cs
+++ b/Fhi.HelseId.Web/Infrastructure/AutomaticTokenManagement/AutomaticTokenManagementCookieEvents.cs
@@ -18,7 +18,9 @@ public class AutomaticTokenManagementCookieEvents : CookieAuthenticationEvents
     private readonly TokenEndpointService _service;
     private readonly AutomaticTokenManagementOptions _tokenConfig;
     private readonly ILogger _logger;
+#pragma warning disable CS0618 // TODO: Use TimeProvider instead. Can be removed when support for Net6.0 is removed.
     private readonly ISystemClock _clock;
+#pragma warning restore CS0618
     private readonly HelseIdWebKonfigurasjon _helseIdConfig;
     private readonly IRefreshTokenStore _refreshTokenStore;
 
@@ -28,7 +30,9 @@ public class AutomaticTokenManagementCookieEvents : CookieAuthenticationEvents
         TokenEndpointService service,
         IOptions<AutomaticTokenManagementOptions> tokenOptions,
         ILogger<AutomaticTokenManagementCookieEvents> logger,
+#pragma warning disable CS0618 // TODO: Use TimeProvider instead. Can be removed when support for Net6.0 is removed.
         ISystemClock clock,
+#pragma warning restore CS0618
         IOptions<HelseIdWebKonfigurasjon> helseIdOptions,
         IRefreshTokenStore refreshTokenStore)
     {


### PR DESCRIPTION
…ider instead.'