### PR TITLE
Fix warning CS8602 and CS8604 in HelseIdSecretHandler - Step 1

### DIFF
--- a/Fhi.HelseId.Web/ExtensionMethods/HelseIdExtensions.cs
+++ b/Fhi.HelseId.Web/ExtensionMethods/HelseIdExtensions.cs
@@ -98,7 +98,7 @@ namespace Fhi.HelseId.Web.ExtensionMethods
                 options.ForwardDPoPContext();
             }
 
-            secretHandler.AddSecretConfiguration(configAuth, options);
+            secretHandler.AddSecretConfiguration(options);
 
             string GetAcrValues(IHelseIdWebKonfigurasjon helseIdWebKonfigurasjon)
             {

--- a/Fhi.HelseId.Web/ExtensionMethods/HelseIdWebAuthBuilder.cs
+++ b/Fhi.HelseId.Web/ExtensionMethods/HelseIdWebAuthBuilder.cs
@@ -51,7 +51,7 @@ public class HelseIdWebAuthBuilder
             throw new MissingConfigurationException($"Missing required configuration {nameof(HelseIdWebKonfigurasjon)}");
         HelseIdWebKonfigurasjon = helseIdWebKonfigurasjon;
         RedirectPagesKonfigurasjon = HelseIdWebKonfigurasjon.RedirectPagesKonfigurasjon;
-        SecretHandler = new HelseIdNoAuthorizationSecretHandler(); // Default
+        SecretHandler = new HelseIdNoAuthorizationSecretHandler(helseIdWebKonfigurasjon); // Default
     }
 
     /// <summary>

--- a/Fhi.HelseId.Web/ExtensionMethods/HelseIdWebAuthBuilderExtensions.cs
+++ b/Fhi.HelseId.Web/ExtensionMethods/HelseIdWebAuthBuilderExtensions.cs
@@ -36,7 +36,7 @@ public static class HelseIdWebAuthBuilderExtensions
     /// </summary>
     public static HelseIdWebAuthBuilder UseJwkKeySecretHandler(this HelseIdWebAuthBuilder authBuilder)
     {
-        authBuilder.SecretHandler = AuthBuilder.HelseIdWebKonfigurasjon.AuthUse ? new HelseIdJwkSecretHandler() : new HelseIdNoAuthorizationSecretHandler();
+        authBuilder.SecretHandler = AuthBuilder.HelseIdWebKonfigurasjon.AuthUse ? new HelseIdJwkSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon) : new HelseIdNoAuthorizationSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon);
         return authBuilder;
     }
 
@@ -45,7 +45,9 @@ public static class HelseIdWebAuthBuilderExtensions
     /// </summary>
     public static HelseIdWebAuthBuilder UseJwkKeyFileSecretHandler(this HelseIdWebAuthBuilder authBuilder)
     {
-        authBuilder.SecretHandler = AuthBuilder.HelseIdWebKonfigurasjon.AuthUse ? new HelseIdJwkFileSecretHandler() : new HelseIdNoAuthorizationSecretHandler();
+
+
+        authBuilder.SecretHandler = AuthBuilder.HelseIdWebKonfigurasjon.AuthUse ? new HelseIdJwkFileSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon) : new HelseIdNoAuthorizationSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon);
         return authBuilder;
     }
     /// <summary>
@@ -53,7 +55,7 @@ public static class HelseIdWebAuthBuilderExtensions
     /// </summary>
     public static HelseIdWebAuthBuilder UseSelvbetjeningFileSecretHandler(this HelseIdWebAuthBuilder authBuilder)
     {
-        authBuilder.SecretHandler = AuthBuilder.HelseIdWebKonfigurasjon.AuthUse ? new HelseIdSelvbetjeningSecretHandler() : new HelseIdNoAuthorizationSecretHandler();
+        authBuilder.SecretHandler = AuthBuilder.HelseIdWebKonfigurasjon.AuthUse ? new HelseIdSelvbetjeningSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon) : new HelseIdNoAuthorizationSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon);
         return authBuilder;
     }
     /// <summary>
@@ -61,7 +63,7 @@ public static class HelseIdWebAuthBuilderExtensions
     /// </summary>
     public static HelseIdWebAuthBuilder UseAzureKeyVaultSecretHandler(this HelseIdWebAuthBuilder authBuilder)
     {
-        authBuilder.SecretHandler = AuthBuilder.HelseIdWebKonfigurasjon.AuthUse ? new HelseIdJwkAzureKeyVaultSecretHandler() : new HelseIdNoAuthorizationSecretHandler();
+        authBuilder.SecretHandler = AuthBuilder.HelseIdWebKonfigurasjon.AuthUse ? new HelseIdJwkAzureKeyVaultSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon) : new HelseIdNoAuthorizationSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon);
         return authBuilder;
     }
 
@@ -70,7 +72,7 @@ public static class HelseIdWebAuthBuilderExtensions
     /// </summary>
     public static HelseIdWebAuthBuilder UseSharedSecretHandler(this HelseIdWebAuthBuilder authBuilder)
     {
-        authBuilder.SecretHandler = AuthBuilder.HelseIdWebKonfigurasjon.AuthUse ? new HelseIdSharedSecretHandler() : new HelseIdNoAuthorizationSecretHandler();
+        authBuilder.SecretHandler = AuthBuilder.HelseIdWebKonfigurasjon.AuthUse ? new HelseIdSharedSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon) : new HelseIdNoAuthorizationSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon);
         return authBuilder;
     }
 

--- a/Fhi.HelseId.Web/ExtensionMethods/HelseIdWebAuthBuilderExtensions.cs
+++ b/Fhi.HelseId.Web/ExtensionMethods/HelseIdWebAuthBuilderExtensions.cs
@@ -45,11 +45,10 @@ public static class HelseIdWebAuthBuilderExtensions
     /// </summary>
     public static HelseIdWebAuthBuilder UseJwkKeyFileSecretHandler(this HelseIdWebAuthBuilder authBuilder)
     {
-
-
         authBuilder.SecretHandler = AuthBuilder.HelseIdWebKonfigurasjon.AuthUse ? new HelseIdJwkFileSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon) : new HelseIdNoAuthorizationSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon);
         return authBuilder;
     }
+
     /// <summary>
     /// For selvbetjening we expect ClientSecret to be a path to a file containing the full downloaded configuration file, including the private key in JWK format
     /// </summary>
@@ -58,6 +57,7 @@ public static class HelseIdWebAuthBuilderExtensions
         authBuilder.SecretHandler = AuthBuilder.HelseIdWebKonfigurasjon.AuthUse ? new HelseIdSelvbetjeningSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon) : new HelseIdNoAuthorizationSecretHandler(AuthBuilder.HelseIdWebKonfigurasjon);
         return authBuilder;
     }
+
     /// <summary>
     /// For Azure Key Vault Secret we expect ClientSecret in the format 'name of secret;uri to vault'. For example: 'MySecret;https://your-unique-key-vault-name.vault.azure.net/'
     /// </summary>
@@ -88,7 +88,6 @@ public static class HelseIdWebAuthBuilderExtensions
     }
 
     public static void UseHelseIdProtectedPaths(this IApplicationBuilder app) => AuthBuilder.UseHelseIdProtectedPaths(app);
-    public static void UseHelseIdProtectedPaths(this IApplicationBuilder app,IReadOnlyCollection<PathString> excludeList, bool overrideDefaults = false) => AuthBuilder.UseHelseIdProtectedPaths(app,excludeList,overrideDefaults);
-    
-    
+    public static void UseHelseIdProtectedPaths(this IApplicationBuilder app,IReadOnlyCollection<PathString> excludeList, bool overrideDefaults = false) => AuthBuilder.UseHelseIdProtectedPaths(app,excludeList,overrideDefaults);  
+   
 }

--- a/Fhi.HelseId.Web/Services/HelseIdSecretHandlers.cs
+++ b/Fhi.HelseId.Web/Services/HelseIdSecretHandlers.cs
@@ -259,7 +259,7 @@ namespace Fhi.HelseId.Web.Services
 
             if (certificates.Count == 0)
             {
-                throw new Exception($"No certificate with thumbprint {ConfigAuth.ClientSecret} found in store LocalMachine");
+                throw new Exception($"No certificate with thumbprint {thumbprint} found in store LocalMachine");
             }
 
             _x509SecurityKey = new X509SecurityKey(certificates[0]);

--- a/Fhi.HelseId.Web/Services/HelseIdSecretHandlers.cs
+++ b/Fhi.HelseId.Web/Services/HelseIdSecretHandlers.cs
@@ -25,11 +25,14 @@ namespace Fhi.HelseId.Web.Services
     {
         protected JsonWebKey JsonWebKey { get; set; }
 
+        protected abstract JsonWebKey GetJsonWebKey();
+
         public const string ClientAssertionType = IdentityModel.OidcConstants.ClientAssertionTypes.JwtBearer;
 
         protected SecretHandlerBase(IHelseIdWebKonfigurasjon helseIdWebKonfigurasjon)
         {
             ConfigAuth = helseIdWebKonfigurasjon;
+            JsonWebKey = GetJsonWebKey();
         }
 
         public virtual void AddSecretConfiguration(OpenIdConnectOptions options) { }
@@ -75,6 +78,11 @@ namespace Fhi.HelseId.Web.Services
             };
 #endif
         }
+
+        protected override JsonWebKey GetJsonWebKey()
+        {
+            return JsonWebKey;
+        }
     }
 
     /// <summary>
@@ -111,6 +119,11 @@ namespace Fhi.HelseId.Web.Services
                 return Task.CompletedTask;
             };
 #endif
+        }
+
+        protected override JsonWebKey GetJsonWebKey()
+        {
+            return JsonWebKey;
         }
     }
 
@@ -168,6 +181,11 @@ namespace Fhi.HelseId.Web.Services
             };
 #endif
         }
+
+        protected override JsonWebKey GetJsonWebKey()
+        {
+            return JsonWebKey;
+        }
     }
 
     /// <summary>
@@ -211,6 +229,11 @@ namespace Fhi.HelseId.Web.Services
                 return Task.CompletedTask;
             };
 #endif
+        }
+
+        protected override JsonWebKey GetJsonWebKey()
+        {
+            return JsonWebKey;
         }
     }
 
@@ -281,6 +304,11 @@ namespace Fhi.HelseId.Web.Services
 
             public string Secret { get; }
         }
+
+        protected override JsonWebKey GetJsonWebKey()
+        {
+            return JsonWebKey;
+        }
     }
 
     public class HelseIdSharedSecretHandler : SecretHandlerBase
@@ -293,12 +321,22 @@ namespace Fhi.HelseId.Web.Services
         {
             options.ClientSecret = ConfigAuth.ClientSecret;
         }
+
+        protected override JsonWebKey GetJsonWebKey()
+        {
+            return JsonWebKey;
+        }
     }
 
     public class HelseIdNoAuthorizationSecretHandler : SecretHandlerBase
     {
         public HelseIdNoAuthorizationSecretHandler(IHelseIdWebKonfigurasjon helseIdWebKonfigurasjon) : base(helseIdWebKonfigurasjon)
         {
+        }
+
+        protected override JsonWebKey GetJsonWebKey()
+        {
+            return JsonWebKey;
         }
     }
 
@@ -369,6 +407,11 @@ namespace Fhi.HelseId.Web.Services
             public string? PrivateJwk { get; set; }
             [JsonPropertyName("pkceRequired")]
             public bool PkceRequired { get; set; }
+        }
+
+        protected override JsonWebKey GetJsonWebKey()
+        {
+            return JsonWebKey;
         }
     }
 }


### PR DESCRIPTION
This is the first step of many(?) to clean up HelseIdSecretHandler.

This PR focues only on getting rid of the warnings. In the process the structure is cleaned up quite a bit.

@OsirisTerje I had to go back on the JsonWebKey property - gives warning if not set in base ctor. This may be done better.


Next PR's may include:
- Remove dead / unused code
- Cleanup formatting and variable names
- Cleanup HelseIdSelvbetjeningSecretHandler (has an internal class, warnings etc.)
- Focus on scope - everything is "public" -> Breaking change.