### PR TITLE
Fixed a bug with claims not being mapped correctly

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-      <VersionPrefix>7.0.0</VersionPrefix>
+      <VersionPrefix>7.0.1</VersionPrefix>
       <authors>Folkehelseinstituttet (FHI), Norsk Helsenett (NHN)</authors>
       <Copyright>(c) 2020-2024 Folkehelseinstituttet (FHI), Norsk Helsenett (NHN)</Copyright>
       <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>

--- a/Fhi.HelseId.Api/ExtensionMethods/ServiceCollectionExtensions.cs
+++ b/Fhi.HelseId.Api/ExtensionMethods/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
 using System.Text.Json.Serialization;
 using Fhi.HelseId.Api.Authorization;
 using Fhi.HelseId.Api.DPoP;

--- a/Fhi.HelseId.Api/ExtensionMethods/ServiceCollectionExtensions.cs
+++ b/Fhi.HelseId.Api/ExtensionMethods/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.JsonWebTokens;
 
 
 namespace Fhi.HelseId.Api.ExtensionMethods;
@@ -70,7 +71,7 @@ public static class ServiceCollectionExtensions
             return false;
         }
 
-        JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+        JsonWebTokenHandler.DefaultInboundClaimTypeMap.Clear();
         services.AddControllers(cfg => { cfg.Filters.Add(new AuthorizeFilter(Policies.HidOrApi)); })
             .AddJsonOptions(
                 options => { options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()); });

--- a/Fhi.HelseId.Web/ExtensionMethods/HelseIdWebAuthBuilder.cs
+++ b/Fhi.HelseId.Web/ExtensionMethods/HelseIdWebAuthBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using Fhi.HelseId.Common;
 using Fhi.HelseId.Common.Configuration;

--- a/Fhi.HelseId.Web/ExtensionMethods/HelseIdWebAuthBuilder.cs
+++ b/Fhi.HelseId.Web/ExtensionMethods/HelseIdWebAuthBuilder.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.JsonWebTokens;
 
 namespace Fhi.HelseId.Web.ExtensionMethods;
 
@@ -80,7 +81,7 @@ public class HelseIdWebAuthBuilder
             _services.AddMemoryCache();
             _services.AddSingleton<IHprFactory, HprFactory>();
             _services.AddSingleton<IAuthorizationHandler, SecurityLevelClaimHandler>();
-            JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+            JsonWebTokenHandler.DefaultInboundClaimTypeMap.Clear();
 
             if (HelseIdWebKonfigurasjon.UseDPoPTokens)
             {


### PR DESCRIPTION
Claims related to users are not mapped correctly.
![image](https://github.com/user-attachments/assets/4e1e2d06-7ec3-48c3-b9a3-247e233b9788)

To fix this, we need to change the claim mapper as Microsoft introduced a new claim mapper in .net 8:
https://stackoverflow.com/a/77570602/1924825