### PR TITLE
Fixed a bug with IAuthorizationHeaderSetter not being registered for DelegatingHandler

### DIFF
--- a/Fhi.HelseId.Web/ExtensionMethods/HelseIdWebAuthBuilder.cs
+++ b/Fhi.HelseId.Web/ExtensionMethods/HelseIdWebAuthBuilder.cs
@@ -95,11 +95,13 @@ public class HelseIdWebAuthBuilder
                 _services.AddTransient<RefreshTokenBackchannelHandler>();
                 _services.AddHttpClient<TokenEndpointService>()
                     .AddHttpMessageHandler<RefreshTokenBackchannelHandler>();
+                _services.AddTransient<IAuthorizationHeaderSetter, DPoPAuthorizationHeaderSetter>();
             }
             else
             {
                 _services.AddHostedService<DPoPComplianceWarning>();
                 _services.AddHttpClient<TokenEndpointService>();
+                _services.AddTransient<IAuthorizationHeaderSetter, BearerAuthorizationHeaderSetter>();
             }
         }
         else


### PR DESCRIPTION
This PR solves this exception:
```
Some services are not able to be constructed (Error while validating the service descriptor 'ServiceType: Fhi.HelseId.Common.AuthHeaderHandler Lifetime: Transient ImplementationType: Fhi.HelseId.Common.AuthHeaderHandler': Unable to resolve service for type 'Fhi.HelseId.Web.IAuthorizationHeaderSetter' while attempting to activate 'Fhi.HelseId.Common.AuthHeaderHandler'.)
```
We should always register the `IAuthorizationHeaderSetter` in the web auth builder in addition to the refit builder to take into account various use-cases.