### PR TITLE
Fixed a bug with ClientSecret being broken with DPoP for KeyVault

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-      <VersionPrefix>7.0.1</VersionPrefix>
+      <VersionPrefix>7.1.0</VersionPrefix>
       <authors>Folkehelseinstituttet (FHI), Norsk Helsenett (NHN)</authors>
       <Copyright>(c) 2020-2024 Folkehelseinstituttet (FHI), Norsk Helsenett (NHN)</Copyright>
       <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>

--- a/Fhi.HelseId.Tests/DPoP.Web/DPoPTokenCreatorTests.cs
+++ b/Fhi.HelseId.Tests/DPoP.Web/DPoPTokenCreatorTests.cs
@@ -10,25 +10,27 @@ using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Fhi.HelseId.Web.Services;
 
 namespace Fhi.HelseId.Tests.DPoP.Web;
 
 internal class DPoPTokenCreatorTests
 {
     private INonceStore _nonceStore;
-    private ProofKeyConfiguration _keyConfiguration;
     private DPoPTokenCreator _dPoPTokenCreator;
+    private IHelseIdSecretHandler _secretHandler;
 
     [SetUp]
     public void SetUp()
     {
         var rsaKey = new RsaSecurityKey(RSA.Create(2048));
         var jsonWebKey = JsonWebKeyConverter.ConvertFromRSASecurityKey(rsaKey);
-        var dpopJwk = JsonSerializer.Serialize(jsonWebKey);
 
         _nonceStore = Substitute.For<INonceStore>();
-        _keyConfiguration = new ProofKeyConfiguration(dpopJwk);
-        _dPoPTokenCreator = new DPoPTokenCreator(_nonceStore, _keyConfiguration);
+        _secretHandler = Substitute.For<IHelseIdSecretHandler>();
+        _secretHandler.Secret.Returns(jsonWebKey);
+
+        _dPoPTokenCreator = new DPoPTokenCreator(_nonceStore, _secretHandler);
     }
 
     [Test]

--- a/Fhi.HelseId.Tests/DPoP.Web/JsonWebKeyExtensionsTests.cs
+++ b/Fhi.HelseId.Tests/DPoP.Web/JsonWebKeyExtensionsTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Security.Cryptography;
+using Fhi.HelseId.Web.DPoP;
+using Microsoft.IdentityModel.Tokens;
+using NUnit.Framework;
+
+namespace Fhi.HelseId.Tests.DPoP.Web;
+
+public class JsonWebKeyExtensionsTests
+{
+    [Test]
+    public void KeyShouldBeCloned()
+    {
+        // Arrange
+        var rsaKey = new RsaSecurityKey(RSA.Create(2048));
+        var proofKey = JsonWebKeyConverter.ConvertFromSecurityKey(rsaKey);
+        
+        // Act
+        var key = proofKey.AsDPoPJwkSecret();
+        key.Kty = "test";
+
+        // Assert
+        Assert.That(key.Kty, Is.Not.EqualTo(proofKey.Kty));
+    }
+
+    [Test]
+    public void AlgIsSetToPS256ByDefault()
+    {
+        // Arrange
+        var rsaKey = new RsaSecurityKey(RSA.Create(2048));
+        var proofKey = JsonWebKeyConverter.ConvertFromSecurityKey(rsaKey);
+        proofKey.Alg = null;
+        
+        // Act
+        var key = proofKey.AsDPoPJwkSecret();
+
+        // Assert
+        Assert.That(key.Alg, Is.EqualTo("PS256"));
+    }
+}

--- a/Fhi.HelseId.Tests/DPoP.Web/JwtThumbprintAttacherTests.cs
+++ b/Fhi.HelseId.Tests/DPoP.Web/JwtThumbprintAttacherTests.cs
@@ -1,4 +1,6 @@
-﻿using Fhi.HelseId.Web.DPoP;
+﻿using System.Security.Cryptography;
+using Fhi.HelseId.Web.DPoP;
+using Fhi.HelseId.Web.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
@@ -11,18 +13,24 @@ namespace Fhi.HelseId.Tests.DPoP.Web;
 
 internal class JwtThumbprintAttacherTests
 {
-    private ProofKeyConfiguration _keyConfiguration;
     private JwtThumbprintAttacher _thumbprintAttacher;
     private RedirectContext _redirectContext;
-
+    private IHelseIdSecretHandler _secretHandler;
+    
+    private byte[] _expectedThumbprint;
+    
     [SetUp]
     public void SetUp()
     {
-        var proofKey = Substitute.For<JsonWebKey>();
-        proofKey.ComputeJwkThumbprint().Returns([1, 2, 3, 4, 5]);
-        _keyConfiguration = new ProofKeyConfiguration(proofKey);
-        _thumbprintAttacher = new JwtThumbprintAttacher(_keyConfiguration);
+        
+        var rsaKey = new RsaSecurityKey(RSA.Create(2048));
+        var proofKey = JsonWebKeyConverter.ConvertFromSecurityKey(rsaKey);
+        _expectedThumbprint = proofKey.ComputeJwkThumbprint();
+        
         var authScheme = new AuthenticationScheme("test", "test", typeof(IAuthenticationHandler));
+        _secretHandler = Substitute.For<IHelseIdSecretHandler>();
+        _secretHandler.Secret.Returns(proofKey);
+        _thumbprintAttacher = new JwtThumbprintAttacher(_secretHandler);
         _redirectContext = new RedirectContext(
             Substitute.For<HttpContext>(),
             authScheme, new OpenIdConnectOptions(),
@@ -37,7 +45,7 @@ internal class JwtThumbprintAttacherTests
         _thumbprintAttacher.AttachThumbprint(_redirectContext);
 
         // Assert
-        var expectedThumbprint = Base64UrlEncoder.Encode([1, 2, 3, 4, 5]);
+        var expectedThumbprint = Base64UrlEncoder.Encode(_expectedThumbprint);
         Assert.That(_redirectContext.ProtocolMessage.Parameters["dpop_jkt"], Is.EqualTo(expectedThumbprint));
     }
 

--- a/Fhi.HelseId.Tests/DPoP.Web/JwtThumbprintAttacherTests.cs
+++ b/Fhi.HelseId.Tests/DPoP.Web/JwtThumbprintAttacherTests.cs
@@ -22,7 +22,6 @@ internal class JwtThumbprintAttacherTests
     [SetUp]
     public void SetUp()
     {
-        
         var rsaKey = new RsaSecurityKey(RSA.Create(2048));
         var proofKey = JsonWebKeyConverter.ConvertFromSecurityKey(rsaKey);
         _expectedThumbprint = proofKey.ComputeJwkThumbprint();

--- a/Fhi.HelseId.Web/DPoP/DPopTokenCreator.cs
+++ b/Fhi.HelseId.Web/DPoP/DPopTokenCreator.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Fhi.HelseId.Web.Services;
 
 namespace Fhi.HelseId.Web.DPoP;
 
@@ -19,7 +20,7 @@ public interface IDPoPTokenCreator
 
 public class DPoPTokenCreator(
     INonceStore nonceStore,
-    ProofKeyConfiguration keyConfiguration) : IDPoPTokenCreator
+    IHelseIdSecretHandler secretHandler) : IDPoPTokenCreator
 {
     public async Task<string> CreateSignedToken(HttpMethod method, string url, string? nonce = null, string? ath = null)
     {
@@ -41,7 +42,7 @@ public class DPoPTokenCreator(
             claims.Add(new Claim("ath", ath));
         }
 
-        var jwk = keyConfiguration.ProofKey;
+        var jwk = secretHandler.Secret.AsDPoPJwkSecret();
         var signingCredentials = new SigningCredentials(jwk, jwk.Alg);
 
         var jwtSecurityToken = new JwtSecurityToken(claims: claims, signingCredentials: signingCredentials);

--- a/Fhi.HelseId.Web/DPoP/JsonWebKeyExtensions.cs
+++ b/Fhi.HelseId.Web/DPoP/JsonWebKeyExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Fhi.HelseId.Web.DPoP;
+
+public static class JsonWebKeyExtensions
+{
+    public static JsonWebKey AsDPoPJwkSecret(this JsonWebKey key)
+    {
+        var json = JsonSerializer.Serialize(key);
+        var clonedKey = JsonSerializer.Deserialize<JsonWebKey>(json)!;
+        clonedKey.Alg ??= "PS256";
+        
+        return clonedKey;
+    }
+}

--- a/Fhi.HelseId.Web/DPoP/JwtThumbprintAttacher.cs
+++ b/Fhi.HelseId.Web/DPoP/JwtThumbprintAttacher.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+﻿using Fhi.HelseId.Web.Services;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Fhi.HelseId.Web.DPoP;
@@ -8,11 +9,12 @@ public interface IProofRedirector
     void AttachThumbprint(RedirectContext ctx);
 }
 
-public class JwtThumbprintAttacher(ProofKeyConfiguration keyConfiguration) : IProofRedirector
+public class JwtThumbprintAttacher(IHelseIdSecretHandler secretHandler) : IProofRedirector
 {
     public void AttachThumbprint(RedirectContext ctx)
     {
-        var jkt = Base64UrlEncoder.Encode(keyConfiguration.ProofKey.ComputeJwkThumbprint());
+        var dpopSecret = secretHandler.Secret.AsDPoPJwkSecret();
+        var jkt = Base64UrlEncoder.Encode(dpopSecret.ComputeJwkThumbprint());
 
         ctx.Properties.Items[DPoPContext.ContextKey] = "true";
         ctx.ProtocolMessage.Parameters["dpop_jkt"] = jkt;


### PR DESCRIPTION
If using any other means of configuring HelseID other than reading from appsettings.json, DPoP would be broken since it would attempt to read a "ClientSecret" value that had never been set. This PR fixes this problem by using the HelseIdSecretHandler instead. It also removes the HelseIdEnterpriseCertificateSecretHandler since this class was not in use and did not use a Jwk similar to other configuration approaches.

Resolves #527 