### PR TITLE
Add note about how ProtectedPathsMiddleware affects authorization

### DIFF
--- a/Fhi.HelseId.Web/Middleware/ProtectedPaths.cs
+++ b/Fhi.HelseId.Web/Middleware/ProtectedPaths.cs
@@ -63,7 +63,7 @@ namespace Fhi.HelseId.Web.Middleware
                     _logger.LogTrace("ProtectedPaths:User is not authenticated, ChallengeAsync called");
                     return;
                 }
-                
+
                 var authorizationResult = await authorizationService.AuthorizeAsync(httpContext.User, null, _policyName);
                 if (!authorizationResult.Succeeded)
                 {

--- a/Fhi.HelseId.Web/Middleware/ProtectedPaths.cs
+++ b/Fhi.HelseId.Web/Middleware/ProtectedPaths.cs
@@ -38,12 +38,12 @@ namespace Fhi.HelseId.Web.Middleware
             _logger.LogTrace($"ProtectedPaths: Checking path: {path}");
             
             /*
-             * This check is important to ensure that incoming HTTP-calls are authorized towards static files.
-             * If the path to the static resource is not on the exclude list, it would indicate that the user
-             * does not have access to that resource without a valid auth token and associated rights.
-             * A side effect of this is that all calls to controllers will be authorized twice due to the
-             * call AuthorizeAsync which is invoked through both this middleware and as a policy configured on
-             * the controllers themselves.
+            * This check is important to ensure that incoming HTTP-calls are authorized for static files.
+            * If the path to the static resource is not on the exclude list, it indicates that the user
+            * does not have access to that resource without a valid auth token and the associated rights.
+            * A side effect of this is that all calls to controllers will be authorized twice due to the
+            * AuthorizeAsync call, which is invoked both through this middleware and as a policy
+            * configured on the controllers themselves.
              */
             if (!_excludedPaths.Any(path.StartsWithSegments))
             {


### PR DESCRIPTION
See diff for technical explanation of how the Protected Paths middleware leads to authorization handlers being invoked twice.