### PR TITLE
Fix packagereferences 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
       <PackageReadmeFile>README.md</PackageReadmeFile>
       <PackageIcon>fhi.png</PackageIcon>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+      <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
       <!-- Vulnerability severity level: NU1991 Low, NU1902 Moderate, NU1903 High, NU1904 Critical -->
       <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>      
       <IncludeSymbols>true</IncludeSymbols>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,33 +4,32 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AspNetCore.DataProtection.SqlServer" Version="1.0.2" />
-    <PackageVersion Include="Azure.Identity" Version="1.13.1" />
+    <PackageVersion Include="Azure.Identity" Version="1.13.2" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Fhi.HelseId.Web" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="morelinq" Version="4.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.4.0" />
-    <PackageVersion Include="NUnit" Version="4.2.2" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.6.0" />
+    <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
     <PackageVersion Include="Refit" Version="8.0.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageVersion Include="Fhi.ClientCredentialsKeypairs" Version="2.0.3" />
+    <PackageVersion Include="Fhi.ClientCredentialsKeypairs" Version="3.0.0" />
     <PackageVersion Include="System.ServiceModel.Duplex" Version="6.0.0" />
     <PackageVersion Include="System.ServiceModel.Federation" Version="8.0.0" />
     <PackageVersion Include="System.ServiceModel.Http" Version="8.0.0" />
     <PackageVersion Include="System.ServiceModel.NetTcp" Version="8.1.0" />
     <PackageVersion Include="System.ServiceModel.Security" Version="6.0.0" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.1" />
+    <PackageVersion Include="System.Formats.Asn1" Version="9.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.1" />
     <!-- Direct reference, System.Security.Cryptography.Xml can be removed when transitive references are fixed. (4.4.0 was vulnerable) -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.1" />
     <!-- Direct references for transitive references. These packages must remain in sync. 
 			 For more information, visit: https://docs.duendesoftware.com/identityserver/v7/troubleshooting/wilson/
 			 or: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2514 -->
@@ -44,7 +43,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,22 +33,22 @@
     <!-- Direct references for transitive references. These packages must remain in sync. 
 			 For more information, visit: https://docs.duendesoftware.com/identityserver/v7/troubleshooting/wilson/
 			 or: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2514 -->
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.2.1" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols" Version="8.2.1" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.3.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols" Version="8.3.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.3.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
     <!-- End direct references -->
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,18 +38,10 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols" Version="8.2.1" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
-    <!-- End direct references -->
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <!-- End direct references -->
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,10 +38,18 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols" Version="8.2.1" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <!-- End direct references -->
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
-    <!-- End direct references -->
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/Fhi.HelseId.Api.Tests/Fhi.HelseId.Api.Tests.csproj
+++ b/Fhi.HelseId.Api.Tests/Fhi.HelseId.Api.Tests.csproj
@@ -12,15 +12,21 @@
     <ProjectReference Include="..\Fhi.HelseId.Testframework\Fhi.TestFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Fhi.ClientCredentialsKeypairs" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="NSubstitute" />
-    <PackageReference Include="Fhi.ClientCredentialsKeypairs" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Fhi.HelseId.Api.Tests/IntegrationTests/DPoPTests.cs
+++ b/Fhi.HelseId.Api.Tests/IntegrationTests/DPoPTests.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Text.Json;
 using Fhi.ClientCredentialsKeypairs;
-using Fhi.HelseId.Api;
 using Fhi.HelseId.Api.ExtensionMethods;
 using Fhi.HelseId.Integration.Tests.HelseId.Api.Setup;
 using Fhi.TestFramework;

--- a/Fhi.HelseId.Api/Fhi.HelseId.Api.csproj
+++ b/Fhi.HelseId.Api/Fhi.HelseId.Api.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Configurations>Debug;Release</Configurations>
     <PackageDescription>Authentication and authorization component for access to NHN HelseId</PackageDescription>

--- a/Fhi.HelseId.Common/Fhi.HelseId.Common.csproj
+++ b/Fhi.HelseId.Common/Fhi.HelseId.Common.csproj
@@ -18,12 +18,12 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" VersionOverride="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" VersionOverride="9.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" VersionOverride="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" VersionOverride="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Fhi.HelseId.Common\README.md" Pack="true" PackagePath="\" />

--- a/Fhi.HelseId.Common/Fhi.HelseId.Common.csproj
+++ b/Fhi.HelseId.Common/Fhi.HelseId.Common.csproj
@@ -18,12 +18,12 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" VersionOverride="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" VersionOverride="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" VersionOverride="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" VersionOverride="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Fhi.HelseId.Common\README.md" Pack="true" PackagePath="\" />

--- a/Fhi.HelseId.Common/Fhi.HelseId.Common.csproj
+++ b/Fhi.HelseId.Common/Fhi.HelseId.Common.csproj
@@ -17,6 +17,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" VersionOverride="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" VersionOverride="9.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" VersionOverride="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" VersionOverride="9.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="..\Fhi.HelseId.Common\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/Fhi.HelseId.Common/Fhi.HelseId.Common.csproj
+++ b/Fhi.HelseId.Common/Fhi.HelseId.Common.csproj
@@ -17,14 +17,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" VersionOverride="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" VersionOverride="9.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" VersionOverride="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" VersionOverride="9.0.0" />
-  </ItemGroup>
   <ItemGroup>
     <None Include="..\Fhi.HelseId.Common\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/Fhi.HelseId.TestSupport/Fhi.HelseId.TestSupport.csproj
+++ b/Fhi.HelseId.TestSupport/Fhi.HelseId.TestSupport.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" />
     <PackageReference Include="NUnit" />
-    <PackageReference Include="morelinq" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Fhi.HelseId.Tests/Fhi.HelseId.Tests.csproj
+++ b/Fhi.HelseId.Tests/Fhi.HelseId.Tests.csproj
@@ -7,8 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="nunit" />
     <PackageReference Include="NUnit.Analyzers">

--- a/Fhi.HelseId.Web/Fhi.HelseId.Web.csproj
+++ b/Fhi.HelseId.Web/Fhi.HelseId.Web.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
@@ -22,6 +21,16 @@
     <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fhi.HelseId.Common\Fhi.HelseId.Common.csproj" />    

--- a/Fhi.HelseId.Web/Fhi.HelseId.Web.csproj
+++ b/Fhi.HelseId.Web/Fhi.HelseId.Web.csproj
@@ -22,16 +22,6 @@
     <PackageReference Include="System.Security.Cryptography.Pkcs" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" VersionOverride="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" VersionOverride="9.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" VersionOverride="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" VersionOverride="9.0.0" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fhi.HelseId.Common\Fhi.HelseId.Common.csproj" />    
   </ItemGroup>

--- a/Fhi.HelseId.Web/Fhi.HelseId.Web.csproj
+++ b/Fhi.HelseId.Web/Fhi.HelseId.Web.csproj
@@ -23,14 +23,14 @@
     <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" VersionOverride="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" VersionOverride="9.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" VersionOverride="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Analyzers" VersionOverride="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fhi.HelseId.Common\Fhi.HelseId.Common.csproj" />    


### PR DESCRIPTION
Dependabot fails due to two projects targeting .Net8 and .Net9. 
- Update all packages
- remove references not in use
- add EnforceCodeStyleInBuild (dotnet build would not pickup my editorconfig)

