### PR TITLE
Do not pack Fhi.TestFramework

### DIFF
--- a/Fhi.HelseId.Testframework/Fhi.TestFramework.csproj
+++ b/Fhi.HelseId.Testframework/Fhi.TestFramework.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The Github Action for `dotnet pack` [currently fails](https://github.com/FHIDev/Fhi.HelseId/actions/runs/13112774262/job/36580129167) because:
>  error NU5039: The readme file 'README.md' does not exist in the package. [/home/runner/work/Fhi.HelseId/Fhi.HelseId/Fhi.HelseId.Testframework/Fhi.TestFramework.csproj]

We are not (yet) providing Fhi.HelseId.Testframework as a NuGet package, and since the build infrastructure exepcts a readme file, this action fails. Until we make a decision on distributing Fhi.HelseId.Testframework as a package we should set this project as IsPackagable=false to make the Nuget pack action pass.