### PR TITLE
Reduce GitHub action test verbosity output to minimal (default)

### DIFF
--- a/.github/workflows/Fhi.HelseId.CI.yml
+++ b/.github/workflows/Fhi.HelseId.CI.yml
@@ -26,4 +26,4 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Run tests
-        run: dotnet test --no-restore --verbosity normal
+        run: dotnet test --no-restore


### PR DESCRIPTION
When tests are run as part of the CI, the resulted test output is beyond 4000 lines where the majority is logs [such as](https://github.com/FHIDev/Fhi.HelseId/actions/runs/13115852117/job/36589819405): 
```
         Copying file from "C:\Users\runneradmin\.nuget\packages\microsoft.aspnetcore.testhost\8.0.12\lib\net8.0\Microsoft.AspNetCore.TestHost.dll" to "D:\a\Fhi.HelseId\Fhi.HelseId\artifacts\bin\Fhi.TestFramework.Samples\debug\Microsoft.AspNetCore.TestHost.dll".
         Copying file from "C:\Users\runneradmin\.nuget\packages\microsoft.bcl.asyncinterfaces\6.0.0\lib\netstandard2.1\Microsoft.Bcl.AsyncInterfaces.dll" to "D:\a\Fhi.HelseId\Fhi.HelseId\artifacts\bin\Fhi.TestFramework.Samples\debug\Microsoft.Bcl.AsyncInterfaces.dll".
```

This makes it harder to see what is wrong when a test actually fails. The default verbosity option in `dotnet test` is minimal, but we have currently set it to normal. This PR removes this flag and sets it back to minimal so we get less verbose output in our test runs.
