### PR TITLE
Update Fhi.HelseId.CI.yml

### DIFF
--- a/.github/workflows/Fhi.HelseId.CI.yml
+++ b/.github/workflows/Fhi.HelseId.CI.yml
@@ -26,4 +26,4 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Run tests
-        run: dotnet test --no-restore --verbosity normal
+        run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/Fhi.HelseId.CI.yml
+++ b/.github/workflows/Fhi.HelseId.CI.yml
@@ -23,7 +23,7 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --configuration Release --no-restore  --verbosity minimal
+        run: dotnet build --no-restore --configuration Release --verbosity minimal
 
       - name: Run tests
         run: dotnet test --no-build --configuration Release --verbosity normal

--- a/.github/workflows/Fhi.HelseId.CI.yml
+++ b/.github/workflows/Fhi.HelseId.CI.yml
@@ -23,7 +23,7 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --no-restore  --verbosity minimal
 
       - name: Run tests
-        run: dotnet test --no-build --configuration Release --verbosity normal
+        run: dotnet test --no-build  --verbosity minimal

--- a/.github/workflows/Fhi.HelseId.CI.yml
+++ b/.github/workflows/Fhi.HelseId.CI.yml
@@ -23,7 +23,7 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --no-restore  --verbosity minimal
+        run: dotnet build --configuration Release --no-restore  --verbosity minimal
 
       - name: Run tests
-        run: dotnet test --no-build  --verbosity minimal
+        run: dotnet test --no-build --configuration Release --verbosity minimal

--- a/.github/workflows/Fhi.HelseId.CI.yml
+++ b/.github/workflows/Fhi.HelseId.CI.yml
@@ -26,4 +26,4 @@ jobs:
         run: dotnet build --configuration Release --no-restore  --verbosity minimal
 
       - name: Run tests
-        run: dotnet test --no-build --configuration Release --verbosity minimal
+        run: dotnet test --no-build --configuration Release --verbosity normal

--- a/.github/workflows/Fhi.HelseId.CI.yml
+++ b/.github/workflows/Fhi.HelseId.CI.yml
@@ -26,4 +26,4 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Run tests
-        run: dotnet test --no-build --verbosity normal
+        run: dotnet test --no-build --configuration Release --verbosity normal


### PR DESCRIPTION
Test was not dependent upon the build output, so build was run twice.  And, they were run with different configurations.  Set the build verbosity to minimal (like in #611 (so that one can be closed), but test verbosity to normal so that we see the test names. 