### PR TITLE
Add dotnet 9 as target framework for helseid-projects

### DIFF
--- a/Fhi.AuthControllers/Fhi.AuthControllers.csproj
+++ b/Fhi.AuthControllers/Fhi.AuthControllers.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageProjectUrl>https://www.nuget.org/packages/Fhi.AuthControllers</PackageProjectUrl>
     <PackageDescription>Account controllers for use with OAuth and HelseId</PackageDescription>

--- a/Fhi.HelseId.Api/Fhi.HelseId.Api.csproj
+++ b/Fhi.HelseId.Api/Fhi.HelseId.Api.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageProjectUrl>https://www.nuget.org/packages/Fhi.HelseId.Api</PackageProjectUrl>
     <PackageDescription>Authentication and authorization component for access to NHN HelseId</PackageDescription>

--- a/Fhi.HelseId.Refit/Fhi.HelseId.Refit.csproj
+++ b/Fhi.HelseId.Refit/Fhi.HelseId.Refit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageProjectUrl>https://www.nuget.org/packages/Fhi.HelseId.Refit</PackageProjectUrl>
     <PackageDescription>Setup Refit with helseid Apis</PackageDescription>


### PR DESCRIPTION
We have enabled support for dotnet 9 in Fhi.HelseId.Common and Fhi.HelseId.Web.
With this change we enable dotnet 9 for other projects as well.

Tested this for OppslagWeb, and worked as intended.